### PR TITLE
Fix for prettify

### DIFF
--- a/ble.py
+++ b/ble.py
@@ -28,7 +28,7 @@ _ARRAYSIZE = const(20)
     
 
 def prettify(mac_string):
-    return ':'.join('{:2x}'.format(b) for b in mac_string)
+    return ':'.join('{:02x}'.format(b) for b in mac_string)
 
 def timestamp(type='timestamp'):
     yy,mm,dd,dy,hh,MM,ss,ms= machine.RTC().datetime()


### PR DESCRIPTION
prettify function would rerun mac address with gap in the address if the address b' value looks like this for example: b'\xa4\xc18\xd4\x04\xd0' would return:  a4:c1:38:d4: 4:d0